### PR TITLE
Use memoization to calculate factorials for input >= 1000

### DIFF
--- a/Factorials/factorials.py
+++ b/Factorials/factorials.py
@@ -1,8 +1,18 @@
-def factorial(a:int):
+"""
+In python default recursion limit is 1000. 
+Naive recursive implementation will raise RecursionError for numbers >= 1000.
+By using memoization we can calculate factorials of those numbers 
+step by step as shown in the main block.
+"""
+
+def factorial(a:int, results={}):
     """
     handle edge case
     a == 0 or 1 or -ve number
     """
+    if a in results:
+        return results[a]
+
     if a == 0 or a == 1:
         return 1
 
@@ -10,18 +20,23 @@ def factorial(a:int):
         return "Negative Integer is not allowed"
 
     # recursive call
-    return a * factorial(a-1)
+    result = a * factorial(a-1)
 
+    # memoize the result
+    results[a] = result
 
-
-
-
-
+    return result
 
 
 if __name__ == "__main__":
-    n = int(input("Enter the positive integer value: "))
+    n = 9
     answer = factorial(n)
     print(f"{n}! = {answer}")
-    
 
+    n = 900
+    answer = factorial(n)
+    print(f"{n}! = {answer}")
+
+    n = 999
+    answer = factorial(n)
+    print(f"{n}! = {answer}")


### PR DESCRIPTION
In python default recursion limit is 1000. Current implementation will raise `RecursionError` for number >= 1000.
By using memoization we can calculate factorials of higher number than 1000 step by step as shown in the main block.

Note: If you call `factorial(1000)` directly it will still raise the `RecursionError`